### PR TITLE
fix: add @security-severity and @precision tags to all queries

### DIFF
--- a/src/main/ql/InsecureCorsHttpOrigin.ql
+++ b/src/main/ql/InsecureCorsHttpOrigin.ql
@@ -3,6 +3,8 @@
  * @description The CORS handler is configured to allow requests from hosts that are not secured over HTTPS.
  * @kind problem
  * @problem.severity critical
+ * @precision high
+ * @security-severity 7.5
  * @id java/vertx/insecure-cors-http-origin
  * @tags security java/vertx
  */

--- a/src/main/ql/InsecureCorsWildcardOrigin.ql
+++ b/src/main/ql/InsecureCorsWildcardOrigin.ql
@@ -3,6 +3,8 @@
  * @description The CORS handler is configured to allow requests from any hosts.
  * @kind problem
  * @problem.severity critical
+ * @precision high
+ * @security-severity 7.5
  * @id java/vertx/insecure-cors-wildcard
  * @tags security java/vertx
  */

--- a/src/main/ql/InsecureHttpServer.ql
+++ b/src/main/ql/InsecureHttpServer.ql
@@ -3,6 +3,8 @@
  * @description The Vert.x HTTP server establishes connections which are not secured using SSL/TLS.
  * @kind problem
  * @problem.severity high
+ * @precision high
+ * @security-severity 7.5
  * @id java/vertx/insecure-http-server
  * @tags security java/vertx
  */


### PR DESCRIPTION
Without `@security-severity`, CodeQL omits the numeric CVSS score from SARIF output. Adding this tag ensures findings carry a numeric severity score in SARIF results. `@precision` high is also required for inclusion in the security-extended query suite.

Why `@precision high`
All three queries match on exact, statically-determinable conditions — a specific no-argument method call (`createHttpServer()`), a string literal starting with `"http://"`, or the exact literal `"*"`. No data-flow tracking or heuristic inference is involved, making false positives extremely unlikely. `@precision high` is also required for inclusion in the `security-extended` query suite.




